### PR TITLE
Upgrade `lcov-parse` to 0.0.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       ],
       "dependencies": {
           "request" : "2.16.2",
-          "lcov-parse" : "0.0.3"
+          "lcov-parse" : "0.0.4"
       },
       "devDependencies" : {
           "mocha" : "1.8.1",


### PR DESCRIPTION
The `lcov-parse` module has been updated to parse `lcov.info` files that contain no branches but do contain branch summaries. There is no mention of whether or not branch summaries should be omitted when there are no branches. The author of `lcov-parse` assumed this was the case based on output from a program in his tool chain.

Istanbul, on the other hand, produces branch summaries even if the source contains no branches. The `genhtml` utility that comes with `lcov` happily parses Istanbul output, but `lcov-parse` 0.0.3 would not.

`lcov-parse` 0.0.4 will parse Istanbul `lcov` output. This commit updates the `package.json` dependencies to include `lcov-parse` 0.0.4.

It is probably best to continue to use specific version numbers for `lcov-parse` as it appears to be in its early days.

See: https://github.com/davglass/lcov-parse/issues/3.
