### PR TITLE
check if file path is already absoluted

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -12,8 +12,12 @@ var detailsToCoverage = function(length, details){
 };
 
 var convertLcovFileObject = function(file, filepath){
-	var fullpath = path.join(filepath, file.file);
-	var source = fs.readFileSync(fullpath, 'utf8');
+	if (file.file[0] !== '/'){
+	  filepath = path.join(filepath, file.file);
+	} else {
+	  filepath = file.file;
+	}
+	var source = fs.readFileSync(filepath, 'utf8');
 	var lines = source.split("\n");
 	var coverage = detailsToCoverage(lines.length, file.lines.details);
 	return { name     : file.file,


### PR DESCRIPTION
hi.

Istanbul produces an already absoluted file paths in output lcov, so node-coveralls should check for this and do not "double" it with `var fullpath = path.join(filepath, file.file);`
