### PR TITLE
use a native js yaml parser instead of a C library

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-var YAML = require('libyaml');
+var yaml = require('yaml');
 var logger = require('./logger');
 
 var getOptions = function(){
@@ -25,7 +25,7 @@ var getOptions = function(){
     var yml = path.join(process.cwd(), '.coveralls.yml');
     try {
       if (fs.statSync(yml).isFile()) {
-        options.repo_token = YAML.readFileSync(yml)[0].repo_token;
+        options.repo_token = yaml.eval(fs.readFileSync(yml, 'utf8')).repo_token;
       }
     } catch(ex){
       logger.warn("Repo token could not be determined.  Continuing without it.");

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"Arpad Borsos <arpad.borsos@googlemail.com> (http://swatinem.de/)"
   ],
   "dependencies": {
-    "libyaml": "0.2.2",
+    "yaml": "0.2.3",
     "request": "2.16.2",
     "lcov-parse": "0.0.4",
     "log-driver": "1.2.1"


### PR DESCRIPTION
I don’t really like the idea of compiling a C lib on `npm install` just to read a single prop out of a yaml file.
