### PR TITLE
Added ability to turn on debug logging via environment variable

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,8 +1,18 @@
 module.exports = function(){
-  if (process.argv[2]) {
-    if (~['-v', '--verbose'].indexOf(process.argv[2])) {
-      return require('log-driver')({level : 'debug'});
-    }
-  }
-  return require('log-driver')({level : 'warn'});
+  return require('log-driver')({level : getLogLevel()});
 };
+
+function getLogLevel(){
+  if (hasVerboseCommandLineOption() || hasDebugEnvVariable()) {
+    return 'debug';
+  }
+  return 'warn';
+}
+
+function hasVerboseCommandLineOption(){
+    return process.argv[2] && ~['-v', '--verbose'].indexOf(process.argv[2]);
+}
+
+function hasDebugEnvVariable(){
+    return process.env.NODE_COVERALLS_DEBUG == 1;
+}

--- a/test/logger.js
+++ b/test/logger.js
@@ -8,4 +8,25 @@ describe("logger", function(){
     var logger = require('../index').logger();
     logger.level.should.equal('debug');
   });
+
+  it ("should log at debug level when NODE_COVERALLS_DEBUG is set in env", function(){
+    process.argv = [];
+    process.env.NODE_COVERALLS_DEBUG = 1;
+    var logger = require('../index').logger();
+    logger.level.should.equal('debug');
+  });
+
+  it ("should log at debug level when NODE_COVERALLS_DEBUG is set in env as a string", function(){
+    process.argv = [];
+    process.env.NODE_COVERALLS_DEBUG = '1';
+    var logger = require('../index').logger();
+    logger.level.should.equal('debug');
+  });
+
+  it ("should log at warn level when NODE_COVERALLS_DEBUG not set and no --verbose", function(){
+    process.argv = [];
+    process.env.NODE_COVERALLS_DEBUG = 0;
+    var logger = require('../index').logger();
+    logger.level.should.equal('warn');
+  });
 });


### PR DESCRIPTION
For the grunt-karma-coveralls project, I need to be able to turn on
debug level logging but without using `process.argv`. This will allow me
to do so.

This addresses this issue:
https://github.com/mattjmorrison/grunt-karma-coveralls/issues/2

and can be fixed with this commit:
https://github.com/mattjmorrison/grunt-karma-coveralls/commit/4bd6e2b58647dda4a6335fa6077334d8021e23c0
