### PR TITLE
npm >=1.1.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "engines": {
     "node": ">=0.8.6",
-    "npm": "1.1.65"
+    "npm": ">=1.1.65"
   },
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This makes npm happy.

```
npm WARN engine coveralls@2.6.0: wanted: {"node":">=0.8.6","npm":"1.1.65"} (current: {"node":"v0.10.18","npm":"1.3.8"})
```
