### PR TITLE
Add callback to handleInput() for easier use in other projects

### DIFF
--- a/bin/coveralls.js
+++ b/bin/coveralls.js
@@ -13,6 +13,10 @@ process.stdin.on('data', function(chunk) {
 });
 
 process.stdin.on('end', function() {
-    handleInput(input);
+    handleInput(input, function(err) {
+      if (err) {
+        throw err;
+      }
+    });
 });
 

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -1,31 +1,36 @@
 var index = require('../index');
 var logger = require('./logger')();
 
-function handleInput(input) {
+function handleInput(input, cb) {
   logger.debug(input);
 	var options = index.getOptions(function(err, options){
 
     if (err){
       logger.error("error from getOptions");
-      throw err;
+      cb(err);
+      return;
     }
     logger.debug(options);
 
     index.convertLcovToCoveralls(input, options, function(err, postData){
       if (err){
         logger.error("error from convertLcovToCoveralls");
-        throw err;
+        cb(err);
+        return;
       }
       logger.info("sending this to coveralls.io: ", JSON.stringify(postData));
       index.sendToCoveralls(postData, function(err, response, body){
         if (err){
-          throw err;
+          cb(err);
+          return;
         }
         if (response.statusCode >= 400){
-          throw "Bad response: " + response.statusCode + " " + body;
+          cb("Bad response: " + response.statusCode + " " + body);
+          return;
         }
         logger.debug(response.statusCode);
         logger.debug(body);
+        cb(null);
       });
     });
   });

--- a/test/handleInput.js
+++ b/test/handleInput.js
@@ -8,48 +8,71 @@ describe("handleInput", function(){
    afterEach(function() {
         sinon.restoreAll();
       });
-  it ("throws an error when there's an error sending", function(done){
+  it ("returns an error when there's an error getting options", function(done){
+    sinon.stub(index, 'getOptions', function(cb){
+      return cb("some error", {}); 
+    });
+    var path = __dirname + "/../fixtures/onefile.lcov";
+    var input = fs.readFileSync(path, "utf8");
+    index.handleInput(input, function(err){
+      err.should.equal("some error");
+      done();
+    });
+  });
+  it ("returns an error when there's an error converting", function(done){
+    sinon.stub(index, 'getOptions', function(cb){
+      return cb(null, {}); 
+    });
+    sinon.stub(index, 'convertLcovToCoveralls', function(input, options, cb){
+      cb("some error");
+    });
+    var path = __dirname + "/../fixtures/onefile.lcov";
+    var input = fs.readFileSync(path, "utf8");
+    index.handleInput(input, function(err){
+      err.should.equal("some error");
+      done();
+    });
+  });
+  it ("returns an error when there's an error sending", function(done){
     sinon.stub(index, 'getOptions', function(cb){
       return cb(null, {}); 
     });
     sinon.stub(index, 'sendToCoveralls', function(postData, cb){
-      try {
-        cb("some error");
-        should.fail("expected exception was not raised");
-      } catch (ex) {
-        done();
-      }
+      cb("some error");
     });
-		var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = __dirname + "/../fixtures/onefile.lcov";
     var input = fs.readFileSync(path, "utf8");
-		index.handleInput(input);
+    index.handleInput(input, function(err){
+      err.should.equal("some error");
+      done();
+    });
   });
-  it ("throws an error when there's a bad status code", function(done){
+  it ("returns an error when there's a bad status code", function(done){
     sinon.stub(index, 'getOptions', function(cb){
       return cb(null, {}); 
     });
     sinon.stub(index, 'sendToCoveralls', function(postData, cb){
-      try {
-        cb(null, {statusCode : 500}, "body");
-        should.fail("expected exception was not raised");
-      } catch (ex) {
-        done();
-      }
+      cb(null, {statusCode : 500}, "body");
     });
-		var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = __dirname + "/../fixtures/onefile.lcov";
     var input = fs.readFileSync(path, "utf8");
-		index.handleInput(input);
+    index.handleInput(input, function(err){
+      err.should.equal("Bad response: 500 body");
+      done();
+    });
   });
-  it ("completes successfully when there are now errors", function(done){
+  it ("completes successfully when there are no errors", function(done){
     sinon.stub(index, 'getOptions', function(cb){
       return cb(null, {}); 
     });
     sinon.stub(index, 'sendToCoveralls', function(postData, cb){
       cb(null, {statusCode : 200}, "body");
+    });
+    var path = __dirname + "/../fixtures/onefile.lcov";
+    var input = fs.readFileSync(path, "utf8");
+    index.handleInput(input, function(err){
+      (err === null).should.equal(true);
       done();
     });
-		var path = __dirname + "/../fixtures/onefile.lcov";
-    var input = fs.readFileSync(path, "utf8");
-		index.handleInput(input);
   });
 });


### PR DESCRIPTION
Since handleInput works completely asynchronous it is necessary to
provide a callback function for signaling finished operation.
This allows other project to call the handleInput function.

See https://github.com/pimterry/grunt-coveralls/pull/3
