### PR TITLE
convertLcovToCoveralls should convert absolute source paths to relative paths in output

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -13,11 +13,12 @@ var detailsToCoverage = function(length, details){
 };
 
 var convertLcovFileObject = function(file, filepath){
-  filepath = path.resolve(filepath, file.file);
+  var rootpath = filepath;
+  filepath = path.resolve(rootpath, file.file);
 	var source = fs.readFileSync(filepath, 'utf8');
 	var lines = source.split("\n");
 	var coverage = detailsToCoverage(lines.length, file.lines.details);
-	return { name     : file.file,
+	return { name     : path.relative(rootpath, path.resolve(rootpath, file.file)),
            source   : source,
            coverage : coverage	};
 };


### PR DESCRIPTION
Istanbul puts absolute file paths in the lcov output and node-coveralls passes them unchanged to Coveralls.
Coveralls cannot find the source file on GitHub because the path is wrong.
See https://coveralls.io/files/153108597 as an example.

This change converts absolute file paths from the lcov output to relative paths and everything works as expected again:
https://coveralls.io/files/153144314

The issue affects even this library's Coverall output: https://coveralls.io/files/143652117 :)
