### PR TITLE
convertLcovToCoveralls should output paths with slashes even on windows.

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -18,7 +18,7 @@ var convertLcovFileObject = function(file, filepath){
 	var source = fs.readFileSync(filepath, 'utf8');
 	var lines = source.split("\n");
 	var coverage = detailsToCoverage(lines.length, file.lines.details);
-	return { name     : path.relative(rootpath, path.resolve(rootpath, file.file)),
+	return { name     : path.relative(rootpath, path.resolve(rootpath, file.file)).split( path.sep ).join( "/" ),
            source   : source,
            coverage : coverage	};
 };


### PR DESCRIPTION
When used on windows, the library sends file paths that use backslashes as separators. This patch simply replaces the system separator with slashes.

[Without the patch](https://coveralls.io/builds/797345), it's [impossible to inspect files](https://coveralls.io/files/204861636). [With the patch](https://coveralls.io/builds/797349), [it works](https://coveralls.io/files/204862687).
