### PR TITLE
do not test against versions the dependencies do not support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.9
   - '0.10'
   - '0.11'
 script: make test-coveralls


### PR DESCRIPTION
This patch removes versions 0.8 and 0.9 of node from the travis file so as to avoid false negatives.
