### PR TITLE
Updates request to a more recent version, using stable hawk >1.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "js-yaml": "3.0.1",
-    "request": "2.16.2",
+    "request": "2.32.x",
     "lcov-parse": "0.0.6",
     "log-driver": "1.2.4"
   },


### PR DESCRIPTION
This get\'s rid of any warning when installing the dependencies that hawk and underlying dependencies work only on node 0.8.x.
