### PR TITLE
Add command line params to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ Client-side JS code coverage using [PhantomJS](https://github.com/ariya/phantomj
 lab -r lcov | ./node_modules/.bin/coveralls
 ```
 
+### Command Line Parameters
+Usage: coveralls.js [-v] filepath
+
+#### Optional arguments:
+
+-v, --verbose
+filepath - optionally defines the base filepath of your source files.
 
 ## Running locally
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Usage: coveralls.js [-v] filepath
 #### Optional arguments:
 
 -v, --verbose
+
 filepath - optionally defines the base filepath of your source files.
 
 ## Running locally


### PR DESCRIPTION
I took a quick stab at adding the command line params to the README.

Related to an issue I opened: https://github.com/cainus/node-coveralls/issues/73