### PR TITLE
allow users to pass options through.

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -108,10 +108,12 @@ var getBaseOptions = function(cb){
   }
 };
 
-var getOptions = function(cb){
+var getOptions = function(cb, _userOptions){
   if (!cb){
     throw new Error('getOptions requires a callback');
   }
+
+  var userOptions = _userOptions || {};
 
   getBaseOptions(function(err, options){
     // try to get filepath from the command-line
@@ -124,7 +126,12 @@ var getOptions = function(cb){
         options.filepath = process.argv[2];
       }
     }
-      cb(err, options);
+
+    // lodash or else would be better, but no need for the extra dependency
+    for (var option in userOptions) {
+      options[option] = userOptions[option];
+    }
+    cb(err, options);
   });
 };
 

--- a/lib/handleInput.js
+++ b/lib/handleInput.js
@@ -1,9 +1,10 @@
 var index = require('../index');
 var logger = require('./logger')();
 
-function handleInput(input, cb) {
+function handleInput(input, cb, userOptions) {
   logger.debug(input);
-	var options = index.getOptions(function(err, options){
+  logger.debug('user options ' + userOptions);
+	index.getOptions(function(err, options){
 
     if (err){
       logger.error("error from getOptions");
@@ -33,7 +34,7 @@ function handleInput(input, cb) {
         cb(null);
       });
     });
-  });
+  }, userOptions);
 }
 
 module.exports = handleInput;

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -135,6 +135,14 @@ describe("getOptions", function(){
   it ("should set service_name and service_job_id if it's running on wercker", function(done){
     testWercker(getOptions, done);
   });
+  it ("should override set options with user options", function(done){
+    var userOptions = {service_name: 'OVERRIDDEN_SERVICE_NAME'};
+    process.env.COVERALLS_SERVICE_NAME = "SERVICE_NAME";
+    getOptions(function(err, options){
+      options.service_name.should.equal("OVERRIDDEN_SERVICE_NAME");
+      done();
+    }, userOptions);
+  });
 });
 
 var testServiceJobId = function(sut, done){


### PR DESCRIPTION
I'm using this library in a grunt task to pipe merged lcov results to coveralls. However, the karma-coverage tool outputs relative paths in its lcov output, and because this library grabs its basepath from argv, it doesn't work out of the box.

For instance, calling
```js
grunt lcovMerge
```
produces a base path at ~/dev/my/repo/lcovMerge. My current workaround is to explicitly set argv:

```js
    var oldArgv = process.argv[2];
    process.argv[2] = '';
    require('coveralls').handleInput(lcov, function(err) {
        process.argv[2] = oldArgv;
        if (err) {
            return done(err);
        }
        done();
    });
```

This change would let me pass in the basepath I'd like, and make using this as a library more easy in general.

I maintained backcompat in this commit, at the expense of an odd ordering of parameters - let me know if you'd prefer the more standard ordering.

Also, let me know if you'd like more tests - I considered refactoring the tests so that each of the current getOptions tests had a corresponding test to ensure the overlay happens correctly.