### PR TITLE
Add command line option to write output to stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - stable
   - 4.2
   - 0.10
-  - 0.11
+  - 0.12
 script: make test-coveralls
-
+sudo: false

--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+var minimist = require('minimist');
+
+// this needs to go before the other require()s so that
+// the other files can already use index.options
+exports.options = minimist(process.argv.slice(2), {
+  boolean: ['verbose', 'stdout'],
+  alias: { 'v': 'verbose', 's': 'stdout' }
+});
+
 var dir = './lib/';
 exports.convertLcovToCoveralls = require(dir + 'convertLcovToCoveralls');
 exports.sendToCoveralls = require(dir + 'sendToCoveralls');

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var yaml = require('js-yaml');
+var index = require('../index');
 var logger = require('./logger')();
 var fetchGitData = require('./fetchGitData');
 
@@ -128,9 +129,8 @@ var getOptions = function(cb, _userOptions){
   var userOptions = _userOptions || {};
 
   getBaseOptions(function(err, options){
-    // try to get filepath from the command-line
-    // look into all command line arguments from index 2 which don't start with -
-    var firstNonOptionArgument = process.argv.slice(2).filter(RegExp.prototype.test.bind(/^[^-]/))[0];
+    // minimist populates options._ with non-option command line arguments
+    var firstNonOptionArgument = index.options._[0];
     
     if (firstNonOptionArgument)
       options.filepath = firstNonOptionArgument;

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -129,15 +129,11 @@ var getOptions = function(cb, _userOptions){
 
   getBaseOptions(function(err, options){
     // try to get filepath from the command-line
-    if (process.argv[2]) {
-      if (~['-v', '--verbose'].indexOf(process.argv[2])) {
-        if (process.argv[3]) {
-          options.filepath = process.argv[3];
-        }
-      } else {
-        options.filepath = process.argv[2];
-      }
-    }
+    // look into all command line arguments from index 2 which don't start with -
+    var firstNonOptionArgument = process.argv.slice(2).filter(RegExp.prototype.test.bind(/^[^-]/))[0];
+    
+    if (firstNonOptionArgument)
+      options.filepath = firstNonOptionArgument;
 
     // lodash or else would be better, but no need for the extra dependency
     for (var option in userOptions) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -10,7 +10,8 @@ function getLogLevel(){
 }
 
 function hasVerboseCommandLineOption(){
-    return process.argv[2] && ~['-v', '--verbose'].indexOf(process.argv[2]);
+    // look into command line arguments starting from index 2
+    return process.argv.slice(2).filter(RegExp.prototype.test.bind(/^(-v|--verbose)$/)).length > 0;
 }
 
 function hasDebugEnvVariable(){

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,17 +1,14 @@
+var index = require('../index');
+
 module.exports = function(){
   return require('log-driver')({level : getLogLevel()});
 };
 
 function getLogLevel(){
-  if (hasVerboseCommandLineOption() || hasDebugEnvVariable()) {
+  if (index.options.verbose || hasDebugEnvVariable()) {
     return 'warn';
   }
   return 'error';
-}
-
-function hasVerboseCommandLineOption(){
-    // look into command line arguments starting from index 2
-    return process.argv.slice(2).filter(RegExp.prototype.test.bind(/^(-v|--verbose)$/)).length > 0;
 }
 
 function hasDebugEnvVariable(){

--- a/lib/sendToCoveralls.js
+++ b/lib/sendToCoveralls.js
@@ -1,4 +1,5 @@
 var request = require('request');
+var index = require('../index');
 
 var sendToCoveralls = function(obj, cb){
   var urlBase = 'https://coveralls.io';
@@ -9,7 +10,7 @@ var sendToCoveralls = function(obj, cb){
   var str = JSON.stringify(obj);
   var url = urlBase + '/api/v1/jobs';
   
-  if (hasWriteToStdoutOption()) {
+  if (index.options.stdout) {
     process.stdout.write(str);
     cb(null, { statusCode: 200 }, '');
   } else {
@@ -18,11 +19,5 @@ var sendToCoveralls = function(obj, cb){
     });
   }
 };
-
-function hasWriteToStdoutOption(){
-    // look into command line arguments starting from index 2
-    return process.argv.slice(2).filter(RegExp.prototype.test.bind(/^(-s|--stdout)$/)).length > 0;
-}
-
 
 module.exports = sendToCoveralls;

--- a/lib/sendToCoveralls.js
+++ b/lib/sendToCoveralls.js
@@ -21,7 +21,7 @@ var sendToCoveralls = function(obj, cb){
 
 function hasWriteToStdoutOption(){
     // look into command line arguments starting from index 2
-    return process.argv.slice(2).filter(RegExp.prototype.test.bind(/^(-w|--write)$/)).length > 0;
+    return process.argv.slice(2).filter(RegExp.prototype.test.bind(/^(-s|--stdout)$/)).length > 0;
 }
 
 

--- a/lib/sendToCoveralls.js
+++ b/lib/sendToCoveralls.js
@@ -8,9 +8,21 @@ var sendToCoveralls = function(obj, cb){
 
   var str = JSON.stringify(obj);
   var url = urlBase + '/api/v1/jobs';
-  request.post({url : url, form : { json : str}}, function(err, response, body){
-    cb(err, response, body);
-  });
+  
+  if (hasWriteToStdoutOption()) {
+    process.stdout.write(str);
+    cb(null, { statusCode: 200 }, '');
+  } else {
+    request.post({url : url, form : { json : str}}, function(err, response, body){
+      cb(err, response, body);
+    });
+  }
 };
+
+function hasWriteToStdoutOption(){
+    // look into command line arguments starting from index 2
+    return process.argv.slice(2).filter(RegExp.prototype.test.bind(/^(-w|--write)$/)).length > 0;
+}
+
 
 module.exports = sendToCoveralls;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "js-yaml": "3.0.1",
     "lcov-parse": "0.0.6",
     "log-driver": "1.2.4",
-    "request": "2.67.0"
+    "request": "2.67.0",
+    "minimist": "1.2.0"
   },
   "devDependencies": {
     "sinon-restore": "1.0.0",

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -70,7 +70,7 @@ describe("getOptions", function(){
     done();
   });
   it ("should get a filepath if there is one", function(done){
-    process.argv[2] = "somepath";
+    index.options._ = ["somepath"];
     getOptions(function(err, options){
       options.filepath.should.equal("somepath");
       done();
@@ -78,8 +78,8 @@ describe("getOptions", function(){
 
   });
   it ("should get a filepath if there is one, even in verbose mode", function(done){
-    process.argv[2] = "--verbose";
-    process.argv[3] = "somepath";
+    index.options.verbose = "true";
+    index.options._ = ["somepath"];
     getOptions(function(err, options){
       options.filepath.should.equal("somepath");
       done();

--- a/test/logger.js
+++ b/test/logger.js
@@ -4,27 +4,27 @@ var index = require('../index');
 
 describe("logger", function(){
   it ("should log at debug level when --verbose is set", function(){
-    process.argv[2] = '--verbose';
+    index.options.verbose = true;
     var logger = require('../index').logger();
     logger.level.should.equal('warn');
   });
 
   it ("should log at debug level when NODE_COVERALLS_DEBUG is set in env", function(){
-    process.argv = [];
+    index.options.verbose = false;
     process.env.NODE_COVERALLS_DEBUG = 1;
     var logger = require('../index').logger();
     logger.level.should.equal('warn');
   });
 
   it ("should log at debug level when NODE_COVERALLS_DEBUG is set in env as a string", function(){
-    process.argv = [];
+    index.options.verbose = false;
     process.env.NODE_COVERALLS_DEBUG = '1';
     var logger = require('../index').logger();
     logger.level.should.equal('warn');
   });
 
   it ("should log at warn level when NODE_COVERALLS_DEBUG not set and no --verbose", function(){
-    process.argv = [];
+    index.options.verbose = false;
     process.env.NODE_COVERALLS_DEBUG = 0;
     var logger = require('../index').logger();
     logger.level.should.equal('error');

--- a/test/sendToCoveralls.js
+++ b/test/sendToCoveralls.js
@@ -1,7 +1,6 @@
 var should = require('should');
 var request = require('request');
 var sinon = require('sinon-restore');
-var stream = require('stream');
 var index = require('../index');
 logger = require('log-driver')({level : false});
 

--- a/test/sendToCoveralls.js
+++ b/test/sendToCoveralls.js
@@ -27,6 +27,7 @@ describe("sendToCoveralls", function(){
     });
 
     var obj = {"some":"obj"};
+    
     index.sendToCoveralls(obj, function(err, response, body){
       err.should.equal('err');
       response.should.equal('response');
@@ -51,7 +52,7 @@ describe("sendToCoveralls", function(){
       done();
     });
   });
-  it ("writes output to stdout when --write is passed", function(done) {
+  it ("writes output to stdout when --stdout is passed", function(done) {
     var obj = {"some":"obj"};
     
     // set up mock process.stdout.write temporarily
@@ -65,7 +66,7 @@ describe("sendToCoveralls", function(){
       origStdoutWrite.apply(this, arguments);
     };
     
-    process.argv[2] = '--write';
+    index.options.stdout = true;
     
     index.sendToCoveralls(obj, function(err, response, body) {
       response.statusCode.should.equal(200);


### PR DESCRIPTION
Adds the command line option pair -w/--write.
These options indicate that the output should be written to standard output,
rather than being posted to coveralls.io, which may be useful for debugging,
mixed-language codebases (e.g. node addons with C++ code) etc.

This includes a test case. In some places, the code was changed to allow a
variable number of command line options (which I would consider useful in
general).