### PR TITLE
Accept more valid git branch names

### DIFF
--- a/lib/detectLocalGit.js
+++ b/lib/detectLocalGit.js
@@ -1,7 +1,8 @@
 var fs = require('fs');
 var path = require('path');
 
-var REGEX_BRANCH = /^ref: refs\/heads\/(\w+)$/;
+// branch naming only has a few excluded characters, see git-check-ref-format(1)
+var REGEX_BRANCH = /^ref: refs\/heads\/([^?*\[\\~^:]+)$/;
 
 module.exports = function detectLocalGit(knownCommit, knownBranch) {
   var dir = process.cwd(), gitDir;


### PR DESCRIPTION
According to git-check-ref-format(1), branch naming excludes a number of characters, but various non-word characters are definitely allowed.
This modifies the `REGEX_BRANCH` detection to match branch names containing some non-word characters, e.g. `features/foo` or `bar-baz`.