### PR TITLE
Fix bug #86

### DIFF
--- a/lib/fetchGitData.js
+++ b/lib/fetchGitData.js
@@ -59,7 +59,7 @@ function fetchBranch(git, cb) {
   });
 }
 
-var REGEX_COMMIT_DETAILS = /\nauthor (.+?) <(.+?)>.+\ncommitter (.+?) <(.+?)>.+\n?[\S\s]+?\n\n(.*)/m;
+var REGEX_COMMIT_DETAILS = /\nauthor (.+?) <([^>]*)>.+\ncommitter (.+?) <([^>]*)>.+\n?[\S\s]+?\n\n(.*)/m;
 
 function fetchHeadDetails(git, cb) {
   exec('git cat-file -p ' + git.head.id, function(err, response) {


### PR DESCRIPTION
Instead of matching the git commit file for emails which contain
at least one character, match for “emails” which also may be empty.

Also, use greedy regex matching in those places which is likely
to be more performant than non-greedy matching.

(#86)