### PR TITLE
Add support for CircleCI commenting on PRs

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -48,6 +48,9 @@ var convertLcovToCoveralls = function(input, options, cb){
     if (options.service_job_id){
       postJson.service_job_id = options.service_job_id;
     }
+    if (options.service_pull_request) {
+      postJson.service_pull_request = options.service_pull_request;
+    }
     if (options.repo_token) {
       postJson.repo_token = options.repo_token;
     }

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -35,7 +35,11 @@ var getBaseOptions = function(cb){
   if (process.env.CIRCLECI){
     options.service_name = 'circleci';
     options.service_job_id = process.env.CIRCLE_BUILD_NUM;
-    options.service_pull_request = process.env.CI_PULL_REQUEST;
+
+    if (process.env.CI_PULL_REQUEST) {
+      var pr = process.env.CI_PULL_REQUEST.split('/pull/');
+      options.service_pull_request = pr[1];
+    }
     git_commit = process.env.CIRCLE_SHA1;
     git_branch = process.env.CIRCLE_BRANCH;
   }

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -35,6 +35,7 @@ var getBaseOptions = function(cb){
   if (process.env.CIRCLECI){
     options.service_name = 'circleci';
     options.service_job_id = process.env.CIRCLE_BUILD_NUM;
+    options.service_pull_request = process.env.CI_PULL_REQUEST;
     git_commit = process.env.CIRCLE_SHA1;
     git_branch = process.env.CIRCLE_BRANCH;
   }

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -282,9 +282,11 @@ var testCircleCi = function(sut, done){
   process.env.CIRCLE_BRANCH = "master";
   process.env.CIRCLE_BUILD_NUM = "1234";
   process.env.CIRCLE_SHA1 = "e3e3e3e3e3e3e3e3e";
+  process.env.CI_PULL_REQUEST = 'http://github.com/node-coveralls/pull/3';
   sut(function(err, options){
     options.service_name.should.equal("circleci");
     options.service_job_id.should.equal("1234");
+    options.service_pull_request.should.equal('http://github.com/node-coveralls/pull/3');
     options.git.should.eql({ head:
                                { id: 'e3e3e3e3e3e3e3e3e',
                                  author_name: 'Unknown Author',

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -286,7 +286,7 @@ var testCircleCi = function(sut, done){
   sut(function(err, options){
     options.service_name.should.equal("circleci");
     options.service_job_id.should.equal("1234");
-    options.service_pull_request.should.equal('http://github.com/node-coveralls/pull/3');
+    options.service_pull_request.should.equal('3');
     options.git.should.eql({ head:
                                { id: 'e3e3e3e3e3e3e3e3e',
                                  author_name: 'Unknown Author',


### PR DESCRIPTION
This adds support for node-coveralls to post the service_pull_request for CircleCI.

- Unfortunately they don't have an environment variable that is the PR number itself, so there is minor string manipulation to get it working.