### PR TITLE
Fix parsing git message with REGEX_COMMIT_DETAILS

### DIFF
--- a/lib/fetchGitData.js
+++ b/lib/fetchGitData.js
@@ -59,7 +59,7 @@ function fetchBranch(git, cb) {
   });
 }
 
-var REGEX_COMMIT_DETAILS = /\nauthor (.+?) <(.+?)>.+\ncommitter (.+?) <(.+?)>.+\n?[\S\s]+?\n\n(.*)/m;
+var REGEX_COMMIT_DETAILS = /\nauthor (.+?) <(.+?)>.+\ncommitter (.+?) <(.+?)>.+[\S\s]*?\n\n(.*)/m;
 
 function fetchHeadDetails(git, cb) {
   exec('git cat-file -p ' + git.head.id, function(err, response) {


### PR DESCRIPTION
Given the commit message

    tree 2d257d54add0901a72fbe492538aec4a35b4f4a5
    parent 21d9ce4eb278af46561e069d6410e72a88c38036
    author Joshua Ma <josh@benchling.com> 1436838814 -0700
    committer Joshua Ma <josh@benchling.com> 1436839048 -0700

    main message

    secondary detail

REGEX_COMMIT_DETAILS previously incorrectly matched `secondary detail` as the
message - it lets an optional newline match (A), followed by nongreedy
`[\S\s]+`, until a double-newline (B) is found. The message used is what
follows B. Since there's two double-newlines, before `main message` and
`secondary detail`, the first double-newline is used towards (A) and the second
set is the one that matches (B). So the message ends up being `secondary
detail`.

This change simplifies the regex to just a nongreedy `[\S\s]*` until the first
double-newline, after which the message is expected.

Fixes https://github.com/lemurheavy/coveralls-public/issues/532