### PR TITLE
Pass CI_PULL_REQUEST through to coveralls if it is set

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -51,6 +51,9 @@ var convertLcovToCoveralls = function(input, options, cb){
     if (options.repo_token) {
       postJson.repo_token = options.repo_token;
     }
+    if (options.service_pull_request) {
+      postJson.service_pull_request = options.service_pull_request;
+    }
     parsed.forEach(function(file){
       postJson.source_files.push(convertLcovFileObject(file, filepath));
     });

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -9,6 +9,12 @@ var getBaseOptions = function(cb){
   var git_commit = process.env.COVERALLS_GIT_COMMIT;
   var git_branch = process.env.COVERALLS_GIT_BRANCH;
 
+  var match = (process.env.CI_PULL_REQUEST || "").match(/(\d+)$/);
+
+  if (match) {
+    options.service_pull_request = match[1];
+  }
+
   if (process.env.TRAVIS){
     options.service_name = 'travis-ci';
     options.service_job_id = process.env.TRAVIS_JOB_ID;

--- a/test/convertLcovToCoveralls.js
+++ b/test/convertLcovToCoveralls.js
@@ -29,6 +29,7 @@ describe("convertLcovToCoveralls", function(){
     process.env.COVERALLS_SERVICE_NAME = "SERVICE_NAME";
     process.env.COVERALLS_SERVICE_JOB_ID = "SERVICE_JOB_ID";
     process.env.COVERALLS_REPO_TOKEN = "REPO_TOKEN";
+    process.env.CI_PULL_REQUEST = "https://github.com/fake/fake/pulls/123";
     
     getOptions(function(err, options){
       var lcovpath = __dirname + "/../fixtures/onefile.lcov";
@@ -37,6 +38,7 @@ describe("convertLcovToCoveralls", function(){
       options.filepath = libpath;
       convertLcovToCoveralls(input, options, function(err, output){
         should.not.exist(err);
+        output.service_pull_request.should.equal("123");
         //output.git.should.equal("GIT_HASH");
         done();
       });

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -115,6 +115,9 @@ describe("getOptions", function(){
   it ("should set service_name if it exists", function(done){
     testServiceName(getOptions, done);
   });
+  it("should set service_pull_request if it exists", function(done){
+    testServicePullRequest(getOptions, done);
+  });
   it ("should set service_name and service_job_id if it's running on travis-ci", function(done){
     testTravisCi(getOptions, done);
   });
@@ -242,6 +245,14 @@ var testServiceName = function(sut, done){
   process.env.COVERALLS_SERVICE_NAME = "SERVICE_NAME";
   sut(function(err, options){
     options.service_name.should.equal("SERVICE_NAME");
+    done();
+  });
+};
+
+var testServicePullRequest = function(sut, done){
+  process.env.CI_PULL_REQUEST = "https://github.com/fake/fake/pulls/123";
+  sut(function(err, options){
+    options.service_pull_request.should.equal("123");
     done();
   });
 };


### PR DESCRIPTION
Resolves: https://github.com/nickmerwin/node-coveralls/issues/100.

The [ruby gem implementation](https://github.com/lemurheavy/coveralls-ruby/blob/master/lib/coveralls/configuration.rb#L50) includes this for a bunch of CI servers.  Not sure if it's required for commenting on pull requests but either way is a nice to have.