### PR TITLE
Added support for process.env.COVERALLS_ENDPOINT

### DIFF
--- a/lib/sendToCoveralls.js
+++ b/lib/sendToCoveralls.js
@@ -1,8 +1,13 @@
 var request = require('request');
 
 var sendToCoveralls = function(obj, cb){
+  var urlBase = 'https://coveralls.io';
+  if (process.env.COVERALLS_ENDPOINT) {
+    urlBase = process.env.COVERALLS_ENDPOINT;
+  }
+
   var str = JSON.stringify(obj);
-  var url = 'https://coveralls.io/api/v1/jobs';
+  var url = urlBase + '/api/v1/jobs';
   request.post({url : url, form : { json : str}}, function(err, response, body){
     cb(err, response, body);
   });

--- a/test/sendToCoveralls.js
+++ b/test/sendToCoveralls.js
@@ -5,9 +5,20 @@ var index = require('../index');
 logger = require('log-driver')({level : false});
 
 describe("sendToCoveralls", function(){
+  var realCoverallsHost;
+  beforeEach(function() {
+    realCoverallsHost = process.env.COVERALLS_ENDPOINT;
+  });
+
   afterEach(function() {
     sinon.restoreAll();
+    if (realCoverallsHost !== undefined) {
+      process.env.COVERALLS_ENDPOINT = realCoverallsHost;
+    } else {
+      delete process.env.COVERALLS_ENDPOINT;
+    }
   });
+
   it ("passes on the correct params to request.post", function(done){
     sinon.stub(request, 'post', function(obj, cb){
       obj.url.should.equal('https://coveralls.io/api/v1/jobs');
@@ -16,12 +27,28 @@ describe("sendToCoveralls", function(){
     });
 
     var obj = {"some":"obj"};
-		index.sendToCoveralls(obj, function(err, response, body){
+	index.sendToCoveralls(obj, function(err, response, body){
       err.should.equal('err');
       response.should.equal('response');
       body.should.equal('body');
       done();
-    
+    });
+  });
+
+  it ("allows sending to enterprise url", function(done){
+    process.env.COVERALLS_ENDPOINT = 'https://coveralls-ubuntu.domain.com';
+    sinon.stub(request, 'post', function(obj, cb){
+      obj.url.should.equal('https://coveralls-ubuntu.domain.com/api/v1/jobs');
+      obj.form.should.eql({json : '{"some":"obj"}'});
+      cb('err', 'response', 'body');
+    });
+
+    var obj = {"some":"obj"};
+	index.sendToCoveralls(obj, function(err, response, body){
+      err.should.equal('err');
+      response.should.equal('response');
+      body.should.equal('body');
+      done();
     });
   });
 });


### PR DESCRIPTION
To allow using this tool with Coveralls Enterprise, I've added support in `sendToCoveralls` to read the host from a `COVERALLS_ENDPOINT` environment variable (if it exists), else default to coveralls.io (as before).