### PR TITLE
Resolve Lodash deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "3.0.1",
     "lcov-parse": "0.0.6",
     "log-driver": "1.2.4",
-    "request": "2.40.0"
+    "request": "2.67.0"
   },
   "devDependencies": {
     "sinon-restore": "1.0.0",


### PR DESCRIPTION
coveralls@^2.6.1 resolves to coveralls@2.11.4, depends on request@2.40.0 - https://github.com/nickmerwin/node-coveralls/blob/master/package.json#L35
request@2.40.0 depends on form-data@~0.1.0 - https://github.com/request/request/blob/v2.40.0/package.json#L33 (so does 3.0, watch out)
form-data@~0.1.0 resolves to @0.1.4, depends on async0.9.2 - https://github.com/form-data/form-data/blob/0.1.4/package.json#L20
async0.9.2 depends on deprecated lodash@2.4.1 - https://github.com/caolan/async/blob/0.9.2/package.json#L28

coveralls@master also depends on request@2.40.0 and should be updated to - https://github.com/request/request/blob/v2.67.0/package.json#L29