### PR TITLE
Add bin/coverallsFromFiles.js that takes filenames as arguments

### DIFF
--- a/bin/coverallsFromFile.js
+++ b/bin/coverallsFromFile.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+var handleInput = require('../lib/handleInput');
+var logger = require('../lib/logger');
+var fs = require('fs');
+
+// Slice off first 2 args: node, /full/path/to/coverallsFromFile.js
+process.argv.slice(2).forEach(function(file) {
+    fs.readFile(file, function(err, data) {
+        if (err) {
+            throw err;
+        } else {
+            // Strip excess whitespace
+            var input = String(data).replace(/^\s+|\s+$/g, '');
+            handleInput(input, function(err) {
+                if (err) {
+                    throw err;
+                }
+            });
+        }
+    });
+});


### PR DESCRIPTION
Previously the way to send your `lcov.info` files to Coveralls was by
piping to `bin/converalls.js`

This adds a script that can be called with `lcov` files as arguments,
then performs the coveralls.js actions on each file.