### PR TITLE
Bump "request" NPM module to fix security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "coverage",
     "coveralls"
   ],
-  "version": "2.11.9",
+  "version": "2.11.10",
   "bugs": {
     "url": "https://github.com/nickmerwin/node-coveralls/issues"
   },
@@ -32,7 +32,7 @@
     "js-yaml": "3.0.1",
     "lcov-parse": "0.0.6",
     "log-driver": "1.2.4",
-    "request": "2.67.0",
+    "request": "2.69.0",
     "minimist": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There's a remote memory exposure vulnerability in the current version of `request`. This bumps that version to the latest current as well as bumping the core packages patch version.

Details here:
https://snyk.io/vuln/npm:request:20160119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nickmerwin/node-coveralls/125)
<!-- Reviewable:end -->
