### PR TITLE
Ignore files that do not exist in convertLcovToCoveralls

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -61,7 +61,10 @@ var convertLcovToCoveralls = function(input, options, cb){
       postJson.service_pull_request = options.service_pull_request;
     }
     parsed.forEach(function(file){
-      postJson.source_files.push(convertLcovFileObject(file, filepath));
+      var currentFilePath = path.resolve(filepath, file.file);
+      if (fs.existsSync(currentFilePath)) {
+        postJson.source_files.push(convertLcovFileObject(file, filepath));
+      }
     });
     return cb(null, postJson);
   });


### PR DESCRIPTION
A project I am working (specifically and Ember application that has several ember addons) on is writing erroneous file paths to it's `lcov.dat` file. 

This fix would cause graceful failure.

I did not add logging, but I can do that if if you feel it's necessary.