### PR TITLE
Rewrite local git detection using git command

### DIFF
--- a/lib/detectLocalGit.js
+++ b/lib/detectLocalGit.js
@@ -1,8 +1,6 @@
+var execSync = require('child_process').execSync;
 var fs = require('fs');
 var path = require('path');
-
-// branch naming only has a few excluded characters, see git-check-ref-format(1)
-var REGEX_BRANCH = /^ref: refs\/heads\/([^?*\[\\~^:]+)$/;
 
 module.exports = function detectLocalGit() {
   var dir = process.cwd(), gitDir;
@@ -18,11 +16,10 @@ module.exports = function detectLocalGit() {
   if (path.resolve('/') === dir)
     return;
 
-  var head = fs.readFileSync(path.join(dir, '.git', 'HEAD'), 'utf-8').trim();
-  var branch = (head.match(REGEX_BRANCH) || [])[1];
+  var commit = execSync('git rev-parse HEAD', {cwd: dir, encoding: 'utf8'}).trim();
+  var branch = execSync('git rev-parse --abbrev-ref HEAD', {cwd: dir, encoding: 'utf8'}).trim();
   if (!branch)
-    return { git_commit: head };
+    return { git_commit: commit };
 
-  var commit = fs.readFileSync(path.join(dir, '.git', 'refs', 'heads', branch), 'utf-8').trim();
   return { git_commit: commit, git_branch: branch };
 };


### PR DESCRIPTION
We recently encountered a error when we tried to run node-coveralls on a Git tagged revision without a branch. I know it sounds a bit of weird to do that, but it's the default behavior of Phabricator's Diffusion code review tool.

When debugging this issue, I found that we can get required information just using git command, so I rewrote the function and it works on our CircleCI setup.

This is error log:

```
fs.js:549
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                                                  ^

Error: ENOENT: no such file or directory, open '/home/ubuntu/blog/.git/refs/heads/master'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:397:15)
    at detectLocalGit (/home/ubuntu/blog/node_modules/coveralls/lib/detectLocalGit.js:26:19)
    at getBaseOptions (/home/ubuntu/blog/node_modules/coveralls/lib/getOptions.js:92:43)
    at Object.getOptions (/home/ubuntu/blog/node_modules/coveralls/lib/getOptions.js:149:3)
    at handleInput (/home/ubuntu/blog/node_modules/coveralls/lib/handleInput.js:7:8)
    at Socket.<anonymous> (/home/ubuntu/blog/node_modules/coveralls/bin/coveralls.js:16:5)
    at emitNone (events.js:72:20)
    at Socket.emit (events.js:166:7)

cat ./coverage/lcov.info | ./node_modules/.bin/coveralls returned exit code 1
```
