### PR TITLE
Update `request` to v2.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "js-yaml": "3.0.1",
     "lcov-parse": "0.0.6",
     "log-driver": "1.2.4",
-    "request": "2.69.0",
+    "request": "2.74.0",
     "minimist": "1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes upstream `tough-cookie` ReDOS https://nodesecurity.io/advisories/130