### PR TITLE
Add Surf support

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -80,6 +80,11 @@ var getBaseOptions = function(cb){
     git_commit = process.env.APPVEYOR_REPO_COMMIT;
     git_branch = process.env.APPVEYOR_REPO_BRANCH;
   }
+  if(process.env.SURF_SHA1){
+    options.service_name = 'surf';
+    git_commit = process.env.SURF_SHA1;
+    git_branch = process.env.SURF_REF;
+  }
   options.run_at = process.env.COVERALLS_RUN_AT || JSON.stringify(new Date()).slice(1, -1);
   if (process.env.COVERALLS_SERVICE_NAME){
     options.service_name = process.env.COVERALLS_SERVICE_NAME;

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -144,6 +144,9 @@ describe("getOptions", function(){
   it ("should set service_name and service_job_id if it's running on Gitlab", function(done){
     testGitlab(getOptions, done);
   });
+  it ("should set service_name and service_job_id if it's running via Surf", function(done){
+    testSurf(getOptions, done);
+  });
   it ("should override set options with user options", function(done){
     var userOptions = {service_name: 'OVERRIDDEN_SERVICE_NAME'};
     process.env.COVERALLS_SERVICE_NAME = "SERVICE_NAME";
@@ -418,7 +421,7 @@ var testGitlab = function(sut, done) {
   });
 };
 
-var testGitlab = function(sut, done) {
+var testSurf = function(sut, done) {
   process.env.CI_NAME = 'surf';
   process.env.SURF_SHA1 = "e3e3e3e3e3e3e3e3e";
   process.env.SURF_REF = "feature";

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -418,6 +418,26 @@ var testGitlab = function(sut, done) {
   });
 };
 
+var testGitlab = function(sut, done) {
+  process.env.CI_NAME = 'surf';
+  process.env.SURF_SHA1 = "e3e3e3e3e3e3e3e3e";
+  process.env.SURF_REF = "feature";
+  sut(function(err, options){
+    options.service_name.should.equal("surf");
+    options.git.should.eql({ head:
+                               { id: 'e3e3e3e3e3e3e3e3e',
+                                 author_name: 'Unknown Author',
+                                 author_email: '',
+                                 committer_name: 'Unknown Committer',
+                                 committer_email: '',
+                                 message: 'Unknown Commit Message' },
+                              branch: 'feature',
+                              remotes: [] });
+    done();
+  });
+};
+
+
 function ensureLocalGitContext(options) {
   var path = require('path');
   var fs = require('fs');


### PR DESCRIPTION
This PR adds support for [Surf](https://github.com/surf-build/surf), which is a toolkit for making your own CI server for GitHub. 