### PR TITLE
Almost no info available via verbose mode `-v` - change log level to debug

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,7 @@ module.exports = function(){
 
 function getLogLevel(){
   if (index.options.verbose || hasDebugEnvVariable()) {
-    return 'warn';
+    return 'debug';
   }
   return 'error';
 }

--- a/lib/sendToCoveralls.js
+++ b/lib/sendToCoveralls.js
@@ -15,6 +15,7 @@ var sendToCoveralls = function(obj, cb){
     cb(null, { statusCode: 200 }, '');
   } else {
     request.post({url : url, form : { json : str}}, function(err, response, body){
+		console.log(body);
       cb(err, response, body);
     });
   }

--- a/lib/sendToCoveralls.js
+++ b/lib/sendToCoveralls.js
@@ -15,7 +15,6 @@ var sendToCoveralls = function(obj, cb){
     cb(null, { statusCode: 200 }, '');
   } else {
     request.post({url : url, form : { json : str}}, function(err, response, body){
-		console.log(body);
       cb(err, response, body);
     });
   }


### PR DESCRIPTION
I'm attempting to get node-coveralls running inside docker on travis and I'm running into some problems. In trying to figure out what is wrong I discovered that verbose mode simply isn't verbose. Verbose mode currently sets the debug level to `warn` and this PR changes it to debug.