### PR TITLE
Update request module dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 lib-cov/
 coverage.json
 npm-debug.log
+*.swp

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lcov-parse": "0.0.10",
     "log-driver": "1.2.5",
     "minimist": "1.2.0",
-    "request": "2.75.0"
+    "request": "2.79.0"
   },
   "devDependencies": {
     "istanbul": "0.4.4",


### PR DESCRIPTION
The old request module uses a now-deprecated dependency (node-uuid@1.4.7) and so npm always throws a warning like this:
```
npm WARN deprecated node-uuid@1.4.7: use uuid module instead
```
This fixes coveralls such that it is no longer a source for this warning.

There are also some deprecated modules used by your devDependencies, but those are less important to address since they only show up when working directly on coveralls (ie., not when coveralls is included as a dependency).