### PR TITLE
don't hardcode minor version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 node_js:
   - "node"
   - "iojs"
-  - "6.0"
-  - "5.0"
-  - "4.2"
+  - "6"
+  - "5"
+  - "4"
   - "0.12"
   - "0.10"
 script: make test-coveralls


### PR DESCRIPTION
It's making run the CI with older versions of Node releases and more importantly with branches that don't receive security patches.

I also think it will make the CI for https://github.com/nickmerwin/node-coveralls/pull/152 pass.