### PR TITLE
Reenabling Drone

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -24,14 +24,17 @@ var getBaseOptions = function(cb){
     git_branch = process.env.TRAVIS_BRANCH;
   }
 
-  /*
+
   if (process.env.DRONE){
     options.service_name = 'drone';
     options.service_job_id = process.env.DRONE_BUILD_NUMBER;
+    options.service_pull_request = process.env.DRONE_PULL_REQUEST;
+    git_committer_name = process.env.DRONE_COMMIT_AUTHOR;
+    git_committer_email = process.env.DRONE_COMMIT_AUTHOR_EMAIL;
     git_commit = process.env.DRONE_COMMIT;
     git_branch = process.env.DRONE_BRANCH;
+    git_message = process.env.DRONE_COMMIT_MESSAGE;
   }
-  */
 
   if (process.env.JENKINS_URL){
     options.service_name = 'jenkins';

--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -49,11 +49,9 @@ describe("getBaseOptions", function(){
   it ("should set service_name and service_job_id if it's running on codeship", function(done){
     testCodeship(getBaseOptions, done);
   });
-  /*
   it ("should set service_name and service_job_id if it's running on drone", function(done){
     testDrone(getBaseOptions, done);
   });
-  */
   it ("should set service_name and service_job_id if it's running on wercker", function(done){
     testWercker(getBaseOptions, done);
   });
@@ -133,11 +131,9 @@ describe("getOptions", function(){
   it ("should set service_name and service_job_id if it's running on codeship", function(done){
     testCodeship(getOptions, done);
   });
-  /*
   it ("should set service_name and service_job_id if it's running on drone", function(done){
     testDrone(getBaseOptions, done);
   });
-  */
   it ("should set service_name and service_job_id if it's running on wercker", function(done){
     testWercker(getOptions, done);
   });
@@ -365,6 +361,11 @@ var testDrone = function(sut, done) {
   process.env.DRONE_BUILD_NUMBER = '1234';
   process.env.DRONE_COMMIT = "e3e3e3e3e3e3e3e3e";
   process.env.DRONE_BRANCH = "master";
+  process.env.DRONE_PULL_REQUEST = '3';
+  process.env.DRONE_COMMIT_AUTHOR = 'john doe';
+  process.env.DRONE_COMMIT_AUTHOR_EMAIL = 'john@doe.com';
+  process.env.DRONE_COMMIT_MESSAGE = 'msgmsgmsg';
+
   sut(function(err, options){
     options.service_name.should.equal("drone");
     options.service_job_id.should.equal("1234");
@@ -372,9 +373,9 @@ var testDrone = function(sut, done) {
                                { id: 'e3e3e3e3e3e3e3e3e',
                                  author_name: 'Unknown Author',
                                  author_email: '',
-                                 committer_name: 'Unknown Committer',
-                                 committer_email: '',
-                                 message: 'Unknown Commit Message' },
+                                 committer_name: 'john doe',
+                                 committer_email: 'john@doe.com',
+                                 message: 'msgmsgmsg' },
                               branch: 'master',
                               remotes: [] });
     done();


### PR DESCRIPTION
With Drone dropping the hosted service (https://archive.drone.io) and going open source (https://github.com/drone/drone), I wanted to give it and Coveralls a shot. 

My initial setup consisted of setting the COVERALLS_REPO_TOKEN env variable and running `nyc` on top of my `mocha` tests as part of my builds on a self-hosted Drone CI. 

```sh
export COVERALLS_REPO_TOKEN=...
nyc mocha && nyc report | coveralls
```

This worked just dandy™ - but there wasn't enough data being sent through the `coveralls` script to coveralls.io to get the status API / automated comments going. 

--- 

This PR re-enables Drone as a CI environment and supplies some more of the available Drone environment data (http://readme.drone.io/0.5/usage/environment-reference/).

* Drone build number
* PR number
* Commit author name & email
* Commit SHA
* Commit message
* Git Branch

So far, I've made _one_ successful build with Coveralls submitting a comment as well as using the Github Status API. 

![screenie](http://i.imgur.com/Y611KYl.png)