### PR TITLE
Parse commit from packed refs if not available in refs dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ coverage/
 lib-cov/
 coverage.json
 npm-debug.log
+
+# Webstorm IDE
+.idea

--- a/lib/detectLocalGit.js
+++ b/lib/detectLocalGit.js
@@ -23,6 +23,25 @@ module.exports = function detectLocalGit() {
   if (!branch)
     return { git_commit: head };
 
-  var commit = fs.readFileSync(path.join(dir, '.git', 'refs', 'heads', branch), 'utf-8').trim();
+  var commit = _parseCommitHashFromRef(dir, branch);
+
   return { git_commit: commit, git_branch: branch };
 };
+
+function _parseCommitHashFromRef(dir, branch) {
+    var ref = path.join(dir, '.git', 'refs', 'heads', branch);
+    if (fs.existsSync(ref)) {
+        return fs.readFileSync(ref, 'utf-8').trim();
+    } else {
+        // ref does not exist; get it from packed-refs
+        var commit = '';
+        var packedRefs = path.join(dir, '.git', 'packed-refs');
+        var packedRefsText = fs.readFileSync(packedRefs, 'utf-8');
+        packedRefsText.split('\n').forEach(function (line) {
+            if (line.match('refs/heads/'+branch)) {
+                commit = line.split(' ')[0];
+            }
+        });
+        return commit;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "request": "2.79.0"
   },
   "devDependencies": {
+    "fs-extra": "^2.1.2",
     "istanbul": "0.4.5",
     "jshint": "2.9.3",
     "mocha": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "request": "2.79.0"
   },
   "devDependencies": {
-    "fs-extra": "^2.1.2",
     "istanbul": "0.4.5",
     "jshint": "2.9.3",
     "mocha": "3.2.0",

--- a/test/detectLocalGit.js
+++ b/test/detectLocalGit.js
@@ -20,7 +20,7 @@ describe("detectLocalGit", function() {
         process.chdir(ORIGINAL_CWD);
     });
 
-    it('should ...', function() {
+    it('should get commit hash from packed-refs when refs/heads/master does not exist', function() {
 
         console.log('dir: ' + process.cwd());
         var results = detectLocalGit();
@@ -41,23 +41,22 @@ function _makeTempGitDir() {
 
     fs.mkdirSync(dir);
 
-    const HEAD = path.join(dir, 'HEAD');
-    const packedRefs = path.join(dir, 'packed-refs');
+    var HEAD = path.join(dir, 'HEAD');
+    var packedRefs = path.join(dir, 'packed-refs');
 
     fs.writeFileSync(HEAD, 'ref: refs/heads/master');
-    fs.writeFileSync(packedRefs, "\
-# pack-refs with: peeled fully-peeled\
-0000000000000000000000000000000000000000 refs/heads/other/ref\n\
-0000000000000000ffffffffffffffffffffffff refs/heads/master\n\
-ffffffffffffffffffffffffffffffffffffffff refs/remotes/origin/other\n\
-");
+    fs.writeFileSync(packedRefs, "" +
+"# pack-refs with: peeled fully-peeled\n" +
+"0000000000000000000000000000000000000000 refs/heads/other/ref\n" +
+"0000000000000000ffffffffffffffffffffffff refs/heads/master\n" +
+"ffffffffffffffffffffffffffffffffffffffff refs/remotes/origin/other\n");
 
 }
 
 function _cleanTempGitDir() {
 
     if (!TEMP_GIT_DIR.match('node-coveralls/test')) {
-        throw new Error('Tried to clean a temp git directory that did not match path: node-coveralls/test')
+        throw new Error('Tried to clean a temp git directory that did not match path: node-coveralls/test');
     }
 
     fs.removeSync(TEMP_GIT_DIR);

--- a/test/detectLocalGit.js
+++ b/test/detectLocalGit.js
@@ -1,0 +1,64 @@
+var should = require('should');
+var fs = require('fs-extra');
+var path = require('path');
+
+var detectLocalGit = require('../lib/detectLocalGit');
+
+var ORIGINAL_CWD = process.cwd();
+var TEST_DIR = path.resolve(__dirname);
+var TEMP_GIT_DIR = path.join(TEST_DIR, '.git');
+
+describe("detectLocalGit", function() {
+
+    before(function() {
+        _makeTempGitDir();
+        process.chdir(TEST_DIR);
+    });
+
+    after(function() {
+        _cleanTempGitDir();
+        process.chdir(ORIGINAL_CWD);
+    });
+
+    it('should ...', function() {
+
+        console.log('dir: ' + process.cwd());
+        var results = detectLocalGit();
+        should.exist(results);
+        (results).should.deepEqual({
+            git_commit: '0000000000000000ffffffffffffffffffffffff',
+            git_branch: 'master'
+        });
+    });
+
+});
+
+function _makeTempGitDir() {
+
+    _cleanTempGitDir();
+
+    var dir = TEMP_GIT_DIR;
+
+    fs.mkdirSync(dir);
+
+    const HEAD = path.join(dir, 'HEAD');
+    const packedRefs = path.join(dir, 'packed-refs');
+
+    fs.writeFileSync(HEAD, 'ref: refs/heads/master');
+    fs.writeFileSync(packedRefs, "\
+# pack-refs with: peeled fully-peeled\
+0000000000000000000000000000000000000000 refs/heads/other/ref\n\
+0000000000000000ffffffffffffffffffffffff refs/heads/master\n\
+ffffffffffffffffffffffffffffffffffffffff refs/remotes/origin/other\n\
+");
+
+}
+
+function _cleanTempGitDir() {
+
+    if (!TEMP_GIT_DIR.match('node-coveralls/test')) {
+        throw new Error('Tried to clean a temp git directory that did not match path: node-coveralls/test')
+    }
+
+    fs.removeSync(TEMP_GIT_DIR);
+}

--- a/test/detectLocalGit.js
+++ b/test/detectLocalGit.js
@@ -1,5 +1,5 @@
 var should = require('should');
-var fs = require('fs-extra');
+var fs = require('fs');
 var path = require('path');
 
 var detectLocalGit = require('../lib/detectLocalGit');
@@ -21,8 +21,6 @@ describe("detectLocalGit", function() {
     });
 
     it('should get commit hash from packed-refs when refs/heads/master does not exist', function() {
-
-        console.log('dir: ' + process.cwd());
         var results = detectLocalGit();
         should.exist(results);
         (results).should.deepEqual({
@@ -54,10 +52,26 @@ function _makeTempGitDir() {
 }
 
 function _cleanTempGitDir() {
+    _deleteFolderRecursive(TEMP_GIT_DIR);
+}
 
-    if (!TEMP_GIT_DIR.match('node-coveralls/test')) {
-        throw new Error('Tried to clean a temp git directory that did not match path: node-coveralls/test');
-    }
+function _deleteFolderRecursive(dir) {
 
-    fs.removeSync(TEMP_GIT_DIR);
+  if (!dir.match('node-coveralls/test')) {
+    throw new Error('Tried to clean a temp git directory that did not match path: node-coveralls/test');
+  }
+
+  if(fs.existsSync(dir)) {
+
+    fs.readdirSync(dir).forEach(function(file,index){
+      var curPath = path.join(dir, file);
+      if(fs.lstatSync(curPath).isDirectory()) { // recurse
+        _deleteFolderRecursive(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+
+    fs.rmdirSync(dir);
+  }
 }


### PR DESCRIPTION
In circle-ci I was getting failures due to their git clone process not providing a reference in `.git/refs/heads/master`. If that is not available, get the commit hash from `.git/packed-refs`.