### PR TITLE
Add buildkite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [Coveralls.io](https://coveralls.io/) support for node.js.  Get the great coverage reporting of coveralls.io and add a cool coverage button ( like the one above ) to your README.
 
-Supported CI services: [travis-ci](https://travis-ci.org/), [codeship](https://www.codeship.io/), [circleci](https://circleci.com/), [jenkins](http://jenkins-ci.org/), [Gitlab CI](http://gitlab.com/), [AppVeyor](http://appveyor.com/)
+Supported CI services: [travis-ci](https://travis-ci.org/), [codeship](https://www.codeship.io/), [circleci](https://circleci.com/), [jenkins](http://jenkins-ci.org/), [Gitlab CI](http://gitlab.com/), [AppVeyor](http://appveyor.com/), [Buildkite](https://buildkite.com/)
 
 ## Installation:
 Add the latest version of `coveralls` to your package.json:

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -45,6 +45,17 @@ var getBaseOptions = function(cb){
     git_branch = process.env.GIT_BRANCH || process.env.BRANCH_NAME;
   }
 
+  if (process.env.BUILDKITE){
+    options.service_name = 'buildkite';
+    options.service_job_number = process.env.BUILDKITE_BUILD_NUMBER;
+    options.service_job_id = process.env.BUILDKITE_BUILD_ID;
+    git_commit = process.env.BUILDKITE_COMMIT;
+    git_branch = process.env.BUILDKITE_BRANCH;
+    git_committer_name = process.env.BUILDKITE_BUILD_CREATOR;
+    git_committer_email = process.env.BUILDKITE_BUILD_CREATOR_EMAIL;
+    git_message = process.env.BUILDKITE_MESSAGE;
+  }
+
   if (process.env.CIRCLECI){
     options.service_name = 'circleci';
     options.service_job_id = process.env.CIRCLE_BUILD_NUM;


### PR DESCRIPTION
[Buildkite](https://buildkite.com/) is a continuous integration provider that we would love to see node-coveralls support for.