### PR TITLE
Prevent testRepoTokenDetection race condition

### DIFF
--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -257,8 +257,7 @@ var testRepoTokenDetection = function(sut, done) {
       options.service_name.should.equal(service_name);
     }
     if (synthetic)
-      fs.unlink(file);
-    done();
+      fs.unlink(file, done);
   });
 };
 


### PR DESCRIPTION
- done callback waits for unlink in testRepoTokenDetection to prevent race condition

Previously this would sometimes result in the file referenced by `fs` existing when the next test was executed, resulting in the configuration file's properties being inherited by the next test erroneously. 