### PR TITLE
Fix a mistype in tests: fs.exists -> fs.existsSync

### DIFF
--- a/test/getOptions.js
+++ b/test/getOptions.js
@@ -238,7 +238,7 @@ var testRepoTokenDetection = function(sut, done) {
   var path = require('path');
 
   var file = path.join(process.cwd(), '.coveralls.yml'), token, service_name, synthetic = false;
-  if (fs.exists(file)) {
+  if (fs.existsSync(file)) {
     var yaml = require('js-yaml');
     var coveralls_yml_doc = yaml.safeLoad(fs.readFileSync(yml, 'utf8'));
     token = coveralls_yml_doc.repo_token;


### PR DESCRIPTION
`fs.exists` doesn't return anything and calling it without a callback is useless.
Probably `fs.existsSync` was meant to be called here.

_Note: this was found using a semi-automated ecosystem scan.
I have not tested this change, but looks like an obvious mistype. Placing hopes in CI._

I suggest to additionaly inspect that codepath, because probably some tests/usecases were broken.

Refs: nodejs/node#18668