### PR TITLE
Improve usability

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -148,9 +148,9 @@ var getBaseOptions = function(cb){
       }
     } catch(ex){
       const msg = "Repo token (COVERALLS_REPO_TOKEN) could not be determined. Continuing without it. " +
-        "The token is necessary for private repos only, so may not be an issue."
-      logger.warn('WARNING: ' + msg);
-      (!process.env.COVERALLS_QUIETE || process.env.COVERALLS_QUIETE === false) && console.warn(msg);
+        "The token is necessary for private repos only, so it may not be an issue."
+      logger.warn(msg);
+      (!process.env.COVERALLS_QUIETE || process.env.COVERALLS_QUIETE === false) && console.warn('WARNING: ' + msg);
     }
   }
 

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -147,10 +147,9 @@ var getBaseOptions = function(cb){
         }
       }
     } catch(ex){
-      const msg = "Repo token (COVERALLS_REPO_TOKEN) could not be determined. Continuing without it. " +
-        "The token is necessary for private repos only, so it may not be an issue."
+      const msg = "Repo token (COVERALLS_REPO_TOKEN) not found, continuing without it. If an error occurs try setting it."
       logger.warn(msg);
-      (!process.env.COVERALLS_QUIETE || process.env.COVERALLS_QUIETE === false) && console.warn('WARNING: ' + msg);
+      (!process.env.COVERALLS_QUIETE || process.env.COVERALLS_QUIETE === '0') && console.warn('WARNING: ' + msg);
     }
   }
 

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -147,8 +147,10 @@ var getBaseOptions = function(cb){
         }
       }
     } catch(ex){
-      logger.warn("Repo token could not be determined.  Continuing without it." +
-                  "This is necessary for private repos only, so may not be an issue at all.");
+      const msg = "Repo token (COVERALLS_REPO_TOKEN) could not be determined. Continuing without it. " +
+        "The token is necessary for private repos only, so may not be an issue."
+      logger.warn('WARNING: ' + msg);
+      (!process.env.COVERALLS_QUIETE || process.env.COVERALLS_QUIETE === false) && console.warn(msg);
     }
   }
 


### PR DESCRIPTION
Currently when COVERALLS_REPO_TOKEN is not set Coveralls fails with an error message.

`Bad response: 422 {"message":"Couldn't find a repository matching this job.","error":true}`

For a new user it is not clear what the problem is. There is a warning message, but it is only visible if NODE_COVERALLS_DEBUG is enabled. And even then there is so much debugging information that a user will never see it. 

I have added a warning message that is displayed when COVERALLS_REPO_TOKEN is not set. I also added the environment variable COVERALLS_QUIETE to run in quiete mode if required.