### PR TITLE
Fix Issue #134

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ npm-debug.log
 
 # Webstorm IDE
 .idea
+
+# Visual Studio Code
+.vscode

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 Supported CI services: [travis-ci](https://travis-ci.org/), [codeship](https://www.codeship.io/), [circleci](https://circleci.com/), [jenkins](http://jenkins-ci.org/), [Gitlab CI](http://gitlab.com/), [AppVeyor](http://appveyor.com/), [Buildkite](https://buildkite.com/)
 
 ## Installation:
+(this can be used directly via npx, without needing to install: `npx coveralls`)
+
 Add the latest version of `coveralls` to your package.json:
 ```
 npm install coveralls --save-dev
@@ -20,19 +22,28 @@ npm install mocha-lcov-reporter --save-dev
 
 ## Usage:
 
-This script ( `bin/coveralls.js` ) can take standard input from any tool that emits the lcov data format (including [mocha](http://mochajs.org/)'s [LCov reporter](https://npmjs.org/package/mocha-lcov-reporter)) and send it to coveralls.io to report your code coverage there.
+This script can take standard input from any tool that emits the lcov data format (including [mocha](http://mochajs.org/)'s [LCov reporter](https://npmjs.org/package/mocha-lcov-reporter)) and send it to coveralls.io to report your code coverage there.
 
-Once your app is instrumented for coverage, and building, you need to pipe the lcov output to `./node_modules/coveralls/bin/coveralls.js`.
+Once your app is instrumented for coverage, and building, you need to pipe the lcov output to `npx coveralls`.  In order to communicate coverage results on your behalf, node-coveralls needs to know the secret coveralls repo token for your Coveralls.io repo.  You will, therefore, need to set COVERALLS_REPO_TOKEN in the environment: 
+```sh
+COVERALLS_REPO_TOKEN=****** npx coveralls
+```
 
-This library currently supports [travis-ci](https://travis-ci.org/) with no extra effort beyond piping the lcov output to coveralls. However, if you're using a different build system, there are a few environment variables that are necessary:
-* COVERALLS_SERVICE_NAME  (the name of your build system)
-* COVERALLS_REPO_TOKEN (the secret repo token from coveralls.io)
+### Optional Settings
+There are optional environment variables for controlling information sent to Coveralls.  Many of these are set automatically, but can be overridden:
+* COVERALLS_PARALLEL: indicates that multiple coverage reports will be submitted to Coveralls (more info here: https://github.com/nickmerwin/node-coveralls/issues/134)
+* COVERALLS_SERVICE_NAME:  the name of your build system
+* COVERALLS_SERVICE_NUMBER: (used in conjunction with COVERALLS_PARALLEL) a unique ID used to combine coverage from several jobs into a single coverage report
+* COVERALLS_SERVICE_JOB_ID: (an id that uniquely identifies the build job)
+* COVERALLS_RUN_AT  (a date string for the time that the job ran.  RFC 3339 dates work.  This defaults to your build system's date/time if you don't set it.)
 
-There are optional environment variables for other build systems as well:
-* COVERALLS_SERVICE_JOB_ID  (an id that uniquely identifies the build job)
-* COVERALLS_RUN_AT  (a date string for the time that the job ran.  RFC 3339 dates work.  This defaults to your
-build system's date/time if you don't set it.)
-* COVERALLS_PARALLEL (more info here: https://coveralls.zendesk.com/hc/en-us/articles/203484329)
+### Testing in Parallel
+If running parallel testing suites or builds that generate separate coverage reports for a single version of your codebase, `node-coveralls` needs to indicate to Coveralls that you are submitting multiple coverage reports for the same version of the code.  In order to do that, you must set `COVERALLS_PARALLEL=true` in the environment for `node-coveralls`.  It may also be nececssary for you to set `COVERALLS_SERVICE_NUMBER` if you aren't using `git` or are using multiple different CI services to test a single codebase in parallel.  COVERALLS_SERVICE_NUMBER is used by Coveralls to tie together multiple reports into a global view of test coverage on a particular code branch/revision.
+
+Once all coverage reports have been submitted to Coveralls, it is necessary to signal Coveralls using the [Parallel Builds webhook](https://docs.coveralls.io/parallel-build-webhook).
+
+## Generating Coverage Information
+
 ### [Jest](https://facebook.github.io/jest/)
 - Install [jest](https://facebook.github.io/jest/docs/en/getting-started.html)
 - Use the following to run tests and push files to coveralls: 

--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -78,6 +78,7 @@ var convertLcovToCoveralls = function(input, options, cb){
     }
     if (options.parallel) {
       postJson.parallel = options.parallel;
+      postJson.service_number = options.service_number;
     }
     if (options.service_pull_request) {
       postJson.service_pull_request = options.service_pull_request;

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -133,6 +133,10 @@ var getBaseOptions = function(cb){
     }
   }
 
+  if (process.env.COVERALLS_PARALLEL) {
+    options.parallel = true;
+  }
+
   // try to get the repo token as an environment variable
   if (process.env.COVERALLS_REPO_TOKEN) {
     options.repo_token = process.env.COVERALLS_REPO_TOKEN;
@@ -157,38 +161,28 @@ var getBaseOptions = function(cb){
     options.flag_name = process.env.COVERALLS_FLAG_NAME;
   }
 
-  if (git_commit){
-    fetchGitData({
-      head: {
-        id: git_commit,
-        committer_name: git_committer_name,
-        committer_email: git_committer_email,
-        message: git_message
-      },
-      branch: git_branch
-    }, function(err, git){
-      if (err){
-        logger.warn('there was an error getting git data: ', err);
-      } else {
-        options.git = git;
-      }
-      return cb(err, options);
-    });
-
-    if (process.env.COVERALLS_PARALLEL && !options.service_number) {
-      options.service_number = git_commit;
-    }
-  } else {
+  if (!git_commit){
     return cb(null, options);
   }
-
-  if (process.env.COVERALLS_PARALLEL) {
-    if (!options.service_number) {
-      throw new Error("Unable to determine ID for parallel build");
+  return fetchGitData({
+    head: {
+      id: git_commit,
+      committer_name: git_committer_name,
+      committer_email: git_committer_email,
+      message: git_message
+    },
+    branch: git_branch
+  }, function addGitToOptions(err, git){
+    if (err){
+      logger.warn('there was an error getting git data: ', err);
+    } else {
+      options.git = git;
+      if (options.parallel && !options.service_number) {
+        options.service_number = git_commit;
+      }
     }
-    options.parallel = true;
-  }
-  
+    return cb(err, options);
+  });
 };
 
 var getOptions = function(cb, _userOptions){
@@ -198,7 +192,7 @@ var getOptions = function(cb, _userOptions){
 
   var userOptions = _userOptions || {};
 
-  getBaseOptions(function(err, options){
+  getBaseOptions(function checkAndExtendBaseOptions(err, options){
     // minimist populates options._ with non-option command line arguments
     var firstNonOptionArgument = index.options._[0];
 

--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -19,6 +19,7 @@ var getBaseOptions = function(cb){
 
   if (process.env.TRAVIS){
     options.service_name = 'travis-ci';
+    options.service_number = process.env.TRAVIS_BUILD_ID;
     options.service_job_id = process.env.TRAVIS_JOB_ID;
     options.service_pull_request = process.env.TRAVIS_PULL_REQUEST;
     git_commit = 'HEAD';
@@ -46,6 +47,7 @@ var getBaseOptions = function(cb){
 
   if (process.env.CIRCLECI){
     options.service_name = 'circleci';
+    options.service_number = process.env.CIRCLE_WORKFLOW_ID;
     options.service_job_id = process.env.CIRCLE_BUILD_NUM;
 
     if (process.env.CI_PULL_REQUEST) {
@@ -116,6 +118,9 @@ var getBaseOptions = function(cb){
   if (process.env.COVERALLS_SERVICE_NAME){
     options.service_name = process.env.COVERALLS_SERVICE_NAME;
   }
+  if (process.env.COVERALLS_SERVICE_NUMBER){
+    options.service_number = process.env.COVERALLS_SERVICE_NUMBER;
+  }
   if (process.env.COVERALLS_SERVICE_JOB_ID){
     options.service_job_id = process.env.COVERALLS_SERVICE_JOB_ID;
   }
@@ -126,10 +131,6 @@ var getBaseOptions = function(cb){
       git_commit = git_commit || data.git_commit;
       git_branch = git_branch || data.git_branch;
     }
-  }
-
-  if (process.env.COVERALLS_PARALLEL) {
-    options.parallel = true;
   }
 
   // try to get the repo token as an environment variable
@@ -173,9 +174,21 @@ var getBaseOptions = function(cb){
       }
       return cb(err, options);
     });
+
+    if (process.env.COVERALLS_PARALLEL && !options.service_number) {
+      options.service_number = git_commit;
+    }
   } else {
     return cb(null, options);
   }
+
+  if (process.env.COVERALLS_PARALLEL) {
+    if (!options.service_number) {
+      throw new Error("Unable to determine ID for parallel build");
+    }
+    options.parallel = true;
+  }
+  
 };
 
 var getOptions = function(cb, _userOptions){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coveralls",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/convertLcovToCoveralls.js
+++ b/test/convertLcovToCoveralls.js
@@ -41,6 +41,7 @@ describe("convertLcovToCoveralls", function(){
         should.not.exist(err);
         output.service_pull_request.should.equal("123");
         output.parallel.should.equal(true);
+        output.service_number.should.equal("GIT_HASH");
         //output.git.should.equal("GIT_HASH");
         done();
       });


### PR DESCRIPTION
Fixes Issue #134 by enabling use of `service_number`.
`service_number` defaults to whatever `git_commit` is deduced to be, and can be explicitly set via COVERALLS_SERVICE_NUMBER.  For CircleCI, it's set to CIRCLE_WORKFLOW_ID, and for Travis, it's set to TRAVIS_BUILD_ID.