### PR TITLE
package.json: specify the files to include

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
     "url": "git://github.com/nickmerwin/node-coveralls.git"
   },
   "author": "Gregg Caines",
-  "license": "BSD-2-Clause"
+  "license": "BSD-2-Clause",
+  "files": [
+    "{bin,lib}/*.js",
+    "index.js"
+  ]
 }


### PR DESCRIPTION
`index.js` can be skipped since npm includes by default the file specified in `main`, but I thought better be explicit