### PR TITLE
Switch to GitHub Actions CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Tests
+on: [push, pull_request]
+env:
+  CI: true
+
+jobs:
+  run:
+    name: Node ${{ matrix.node }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [6, 8, 10, 12]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm install # switch to `npm ci` when Node.js 6 support is dropped
+
+      - name: Run tests
+        run: make test-coveralls
+        env:
+          COVERALLS_REPO_TOKEN: "${{ secrets.COVERALLS_REPO_TOKEN }}"
+          COVERALLS_GIT_BRANCH: "${{ github.ref }}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-  - "8"
-  - "6"
-script: make test-coveralls
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-coveralls
 
-[![Build Status][travis-image]][travis-url] [![Coverage Status][coveralls-image]][coveralls-url]
+[![Build Status][ci-image]][ci-url] [![Coverage Status][coveralls-image]][coveralls-url]
 [![Known Vulnerabilities](https://snyk.io/test/github/nickmerwin/node-coveralls/badge.svg)](https://snyk.io/test/github/nickmerwin/node-coveralls)
 
 [Coveralls.io](https://coveralls.io/) support for node.js.  Get the great coverage reporting of coveralls.io and add a cool coverage button ( like the one above ) to your README.
@@ -147,8 +147,8 @@ If you're running locally, you must have a `.coveralls.yml` file, as documented 
 
 If you want to send commit data to coveralls, you can set the `COVERALLS_GIT_COMMIT` environment-variable to the commit hash you wish to reference. If you don't want to use a hash, you can set it to `HEAD` to supply coveralls with the latest commit data. This requires git to be installed and executable on the current PATH.
 
-[travis-image]: https://travis-ci.org/nickmerwin/node-coveralls.svg?branch=master
-[travis-url]: https://travis-ci.org/nickmerwin/node-coveralls
+[ci-image]: https://github.com/nickmerwin/node-coveralls/workflows/Tests/badge.svg
+[ci-url]: https://github.com/nickmerwin/node-coveralls/actions?workflow=Tests
 
 [coveralls-image]: https://coveralls.io/repos/nickmerwin/node-coveralls/badge.svg?branch=master&service=github
 [coveralls-url]: https://coveralls.io/github/nickmerwin/node-coveralls?branch=master


### PR DESCRIPTION
Currently only runs on Ubuntu

The plan is to add Windows too later.

TODO:

- [ ] Replace `TRAVIS_JOB_ID` in Makefile with the Actions equivalent?

Preview: <https://github.com/XhmikosR/node-coveralls/runs/254633787> It fails normally because I don't have the repo added on Coveralls