### PR TITLE
Fix tests on Windows.

### DIFF
--- a/test/convertLcovToCoveralls.js
+++ b/test/convertLcovToCoveralls.js
@@ -9,9 +9,9 @@ logger = require('log-driver')({level : false});
 describe("convertLcovToCoveralls", function(){
   it ("should convert a simple lcov file", function(done){
     delete process.env.TRAVIS;
-    var lcovpath = __dirname + "/../fixtures/onefile.lcov";
+    var lcovpath = path.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(lcovpath, "utf8");
-    var libpath = __dirname + "/../fixtures/lib";
+    var libpath = path.join(__dirname, "/../fixtures/lib");
     convertLcovToCoveralls(input, {filepath: libpath}, function(err, output){
       should.not.exist(err);
       output.source_files[0].name.should.equal("index.js");
@@ -33,7 +33,7 @@ describe("convertLcovToCoveralls", function(){
     process.env.COVERALLS_PARALLEL = "true";
 
     getOptions(function(err, options){
-      var lcovpath = __dirname + "/../fixtures/onefile.lcov";
+      var lcovpath = path.join(__dirname, "/../fixtures/onefile.lcov");
       var input = fs.readFileSync(lcovpath, "utf8");
       var libpath = "fixtures/lib";
       options.filepath = libpath;
@@ -48,7 +48,7 @@ describe("convertLcovToCoveralls", function(){
   });
   it ("should work with a relative path as well", function(done){
     delete process.env.TRAVIS;
-    var lcovpath = __dirname + "/../fixtures/onefile.lcov";
+    var lcovpath = path.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(lcovpath, "utf8");
     var libpath = "fixtures/lib";
     convertLcovToCoveralls(input, {filepath: libpath}, function(err, output){
@@ -61,7 +61,7 @@ describe("convertLcovToCoveralls", function(){
 
   it ("should convert absolute input paths to relative", function(done){
     delete process.env.TRAVIS;
-    var lcovpath = __dirname + "/../fixtures/istanbul.lcov";
+    var lcovpath = path.join(__dirname, "/../fixtures/istanbul.lcov");
     var input = fs.readFileSync(lcovpath, "utf8");
     var libpath = "/Users/deepsweet/Dropbox/projects/svgo/lib";
     var sourcepath = path.resolve(libpath, "svgo/config.js");
@@ -83,14 +83,14 @@ describe("convertLcovToCoveralls", function(){
       fs.existsSync = originalExistsSync;
 
       should.not.exist(err);
-      output.source_files[0].name.should.equal(path.join("svgo", "config.js"));
+      output.source_files[0].name.should.equal(path.posix.join("svgo", "config.js"));
       done();
     });
   });
 
   it ("should handle branch coverage data", function(done){
     process.env.TRAVIS_JOB_ID = -1;
-    var lcovpath = __dirname + "/../fixtures/istanbul.lcov";
+    var lcovpath = path.join(__dirname, "/../fixtures/istanbul.lcov");
     var input = fs.readFileSync(lcovpath, "utf8");
     var libpath = "/Users/deepsweet/Dropbox/projects/svgo/lib";
     var sourcepath = path.resolve(libpath, "svgo/config.js");
@@ -119,7 +119,7 @@ describe("convertLcovToCoveralls", function(){
 
   it ("should ignore files that do not exists", function(done){
     delete process.env.TRAVIS;
-    var lcovpath = __dirname + "/../fixtures/istanbul.lcov";
+    var lcovpath = path.join(__dirname, "/../fixtures/istanbul.lcov");
     var input = fs.readFileSync(lcovpath, "utf8");
     var libpath = "/Users/deepsweet/Dropbox/projects/svgo/lib";
     var sourcepath = path.resolve(libpath, "svgo/config.js");
@@ -148,7 +148,7 @@ describe("convertLcovToCoveralls", function(){
 
   it ("should parse file paths concatenated by typescript and ng 2", function(done) {
     process.env.TRAVIS_JOB_ID = -1;
-    var lcovpath = __dirname + "/../fixtures/istanbul.remap.lcov";
+    var lcovpath = path.join(__dirname, "/../fixtures/istanbul.remap.lcov");
     var input = fs.readFileSync(lcovpath, "utf8");
     var libpath = "/Users/deepsweet/Dropbox/projects/svgo/lib";
     var sourcepath = path.resolve(libpath, "svgo/config.js");
@@ -170,7 +170,7 @@ describe("convertLcovToCoveralls", function(){
       fs.existsSync = originalExistsSync;
 
       should.not.exist(err);
-      output.source_files[0].name.should.equal(path.join("svgo", "config.js"));
+      output.source_files[0].name.should.equal(path.posix.join("svgo", "config.js"));
       done();
     });
   });

--- a/test/detectLocalGit.js
+++ b/test/detectLocalGit.js
@@ -57,8 +57,8 @@ function _cleanTempGitDir() {
 
 function _deleteFolderRecursive(dir) {
 
-  if (!dir.match('node-coveralls/test')) {
-    throw new Error('Tried to clean a temp git directory that did not match path: node-coveralls/test');
+  if (!dir.includes(path.normalize('node-coveralls/test'))) {
+    throw new Error('Tried to clean a temp git directory that did not match path: ' + path.normalize('node-coveralls/test'));
   }
 
   if(fs.existsSync(dir)) {

--- a/test/handleInput.js
+++ b/test/handleInput.js
@@ -1,3 +1,4 @@
+var sysPath = require('path');
 var should = require('should');
 var sinon = require('sinon-restore');
 var index = require('../index');
@@ -12,7 +13,7 @@ describe("handleInput", function(){
     sinon.stub(index, 'getOptions', function(cb){
       return cb("some error", {});
     });
-    var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = sysPath.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(path, "utf8");
     index.handleInput(input, function(err){
       err.should.equal("some error");
@@ -26,7 +27,7 @@ describe("handleInput", function(){
     sinon.stub(index, 'convertLcovToCoveralls', function(input, options, cb){
       cb("some error");
     });
-    var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = sysPath.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(path, "utf8");
     index.handleInput(input, function(err){
       err.should.equal("some error");
@@ -40,7 +41,7 @@ describe("handleInput", function(){
     sinon.stub(index, 'sendToCoveralls', function(postData, cb){
       cb("some error");
     });
-    var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = sysPath.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(path, "utf8");
     index.handleInput(input, function(err){
       err.should.equal("some error");
@@ -54,7 +55,7 @@ describe("handleInput", function(){
     sinon.stub(index, 'sendToCoveralls', function(postData, cb){
       cb(null, {statusCode : 500}, "body");
     });
-    var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = sysPath.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(path, "utf8");
     index.handleInput(input, function(err){
       err.should.equal("Bad response: 500 body");
@@ -68,7 +69,7 @@ describe("handleInput", function(){
     sinon.stub(index, 'sendToCoveralls', function(postData, cb){
       cb(null, {statusCode : 200}, "body");
     });
-    var path = __dirname + "/../fixtures/onefile.lcov";
+    var path = sysPath.join(__dirname, "/../fixtures/onefile.lcov");
     var input = fs.readFileSync(path, "utf8");
     index.handleInput(input, function(err, body){
       (err === null).should.equal(true);


### PR DESCRIPTION
```
C:\Users\xmr\Desktop\node-coveralls>npm run mocha

> coveralls@3.0.6 mocha C:\Users\xmr\Desktop\node-coveralls
> _mocha -b -R spec

  convertLcovToCoveralls
    √ should convert a simple lcov file
    √ should pass on all appropriate parameters from the environment
    √ should work with a relative path as well
    √ should convert absolute input paths to relative
    √ should handle branch coverage data
    √ should ignore files that do not exists
    √ should parse file paths concatenated by typescript and ng 2

  detectLocalGit
    √ should get commit hash from packed-refs when refs/heads/master does not exist

  fetchGitData
    √ should throw an error when no data is passed
    √ should throw an error when no git context is provided
    √ should throw an error if no head is provided
    √ should throw an error if no head.id is provided
    √ should return default values
    √ should override default values
    √ should convert git.branch to a string (76ms)
    √ should convert git.remotes to an array (46ms)
    √ should save passed remotes
    √ should execute git commands when a valid commit hash is given (88ms)

  getBaseOptions
    √ should set service_job_id if it exists (72ms)
    √ should set git hash if it exists
    √ should set git branch if it exists
    √ should detect current git hash if not passed in (73ms)
    √ should detect current git branch if not passed in (91ms)
    √ should detect detached git head if no hash passed in (98ms)
    √ should fail local Git detection if no .git directory
    √ should set repo_token if it exists (71ms)
    √ should detect repo_token if not passed in (83ms)
    √ should set service_name if it exists (71ms)
    √ should set service_name and service_job_id if it's running on travis-ci (71ms)
    √ should set service_name and service_job_id if it's running on jenkins
    √ should set service_name and service_job_id if it's running on circleci (38ms)
    √ should set service_name and service_job_id if it's running on codeship (42ms)
    √ should set service_name and service_job_id if it's running on drone (45ms)
    √ should set service_name and service_job_id if it's running on wercker (38ms)
    √ should set service_name and service_job_id if it's running on Buildkite
    √ should set service_name and service_job_id if it's running on Azure Pipelines

  getOptions
    √ should require a callback
    √ should get a filepath if there is one (82ms)
    √ should get a filepath if there is one, even in verbose mode (71ms)
    √ should set service_job_id if it exists (69ms)
    √ should set git hash if it exists
    √ should set git branch if it exists
    √ should detect current git hash if not passed in (80ms)
    √ should detect current git branch if not passed in (71ms)
    √ should detect detached git head if no hash passed in (97ms)
    √ should fail local Git detection if no .git directory
    √ should set repo_token if it exists (80ms)
    √ should detect repo_token if not passed in (71ms)
    √ should set paralell if env var set (70ms)
    √ should set flag_name if it exists (79ms)
    √ should set service_name if it exists (90ms)
    √ should set service_pull_request if it exists (71ms)
    √ should set service_name and service_job_id if it's running on travis-ci (69ms)
    √ should set service_name and service_job_id if it's running on jenkins
    √ should set service_name and service_job_id if it's running on circleci
    √ should set service_name and service_job_id if it's running on codeship
    √ should set service_name and service_job_id if it's running on drone
    √ should set service_name and service_job_id if it's running on wercker
    √ should set service_name and service_job_id if it's running on Gitlab (46ms)
    √ should set service_name and service_job_id if it's running via Surf
    √ should set service_name and service_job_id if it's running via Buildkite
    √ should set service_name and service_job_id if it's running via Semaphore (49ms)
    √ should set service_name and service_job_id if it's running via Azure Pipelines
    √ should override set options with user options (113ms)

  handleInput
[error] "2019-10-10T06:05:23.682Z"  'error from getOptions'
    √ returns an error when there's an error getting options
[error] "2019-10-10T06:05:23.684Z"  'error from convertLcovToCoveralls'
    √ returns an error when there's an error converting
    √ returns an error when there's an error sending
    √ returns an error when there's a bad status code
    √ completes successfully when there are no errors

  logger
    √ should log at debug level when --verbose is set
    √ should log at debug level when NODE_COVERALLS_DEBUG is set in env
    √ should log at debug level when NODE_COVERALLS_DEBUG is set in env as a string
    √ should log at warn level when NODE_COVERALLS_DEBUG not set and no --verbose

  sendToCoveralls
    √ passes on the correct params to request.post
    √ allows sending to enterprise url
    √ writes output to stdout when --stdout is passed


  76 passing (3s)
```