### PR TITLE
add ability to parse cobertura files

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -1,6 +1,7 @@
 var TRAVIS_JOB_ID = process.env.TRAVIS_JOB_ID || 'unknown';
 var fs = require('fs');
 var lcovParse = require('lcov-parse');
+var coberturaParse = require('cobertura-parse');
 var path = require('path');
 var logger = require('./logger')();
 
@@ -47,11 +48,13 @@ var cleanFilePath = function(file) {
 
 var convertLcovToCoveralls = function(input, options, cb){
   var filepath = options.filepath || '';
+  var filetype = options.filetype || 'lcov';
+  var parser = filetype === 'cobertura' ? coberturaParse.parseContent : lcovParse;
   logger.debug("in: ", filepath);
   filepath = path.resolve(process.cwd(), filepath);
-  lcovParse(input, function(err, parsed){
+  parser(input, function(err, parsed){
     if (err){
-      logger.error("error from lcovParse: ", err);
+      logger.error("error from " + filetype + "Parse: ", err);
       logger.error("input: ", input);
       return cb(err);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coveralls",
-  "version": "3.0.4",
+  "version": "3.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -375,6 +375,83 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
+    },
+    "cobertura-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/cobertura-parse/-/cobertura-parse-1.0.5.tgz",
+      "integrity": "sha512-uYJfkGhzw1wibe/8jqqHmSaPNWFguzq/IlSj83u3cSnZho/lUnfj0mLTmZGmB3AiKCOTYr22TYwpR1sXy2JEkg==",
+      "requires": {
+        "mocha": "5.0.5",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+        },
+        "mocha": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+          "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
+          "requires": {
+            "browser-stdout": "1.3.1",
+            "commander": "2.11.0",
+            "debug": "3.1.0",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "glob": "7.1.2",
+            "growl": "1.10.3",
+            "he": "1.1.1",
+            "mkdirp": "0.5.1",
+            "supports-color": "4.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
     },
     "code-point-at": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "coverage",
     "coveralls"
   ],
-  "version": "3.0.7",
+  "version": "3.0.8",
   "bugs": {
     "url": "https://github.com/nickmerwin/node-coveralls/issues"
   },
@@ -30,6 +30,7 @@
     "Adam Moss (https://github.com/adam-moss)"
   ],
   "dependencies": {
+    "cobertura-parse": "^1.0.5",
     "growl": "~> 1.10.0",
     "js-yaml": "^3.13.1",
     "lcov-parse": "^0.0.10",


### PR DESCRIPTION
This adds support for files that can be produced by pytest and coverage.py and many other job runners.

if this gets merged ill have a small PR for the github action to use this new setting