### PR TITLE
Remove the unused growl dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,7 +1029,8 @@
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
     },
     "handlebars": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "Adam Moss (https://github.com/adam-moss)"
   ],
   "dependencies": {
-    "growl": "~> 1.10.0",
     "js-yaml": "^3.13.1",
     "lcov-parse": "^0.0.10",
     "log-driver": "^1.2.7",


### PR DESCRIPTION
This will conflict with #234 but I can rebase either one when needed.