### PR TITLE
CI: use `npm ci` on Node.js >=8.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,14 @@ jobs:
       - run: node --version
       - run: npm --version
 
-      - name: Install npm dependencies
-        run: npm install # switch to `npm ci` when Node.js 6 support is dropped
+       # remove this block when Node.js 6.x is dropped
+      - name: Install npm dependencies (npm i)
+        run: npm install
+        if: matrix.node < 8
+
+      - name: Install npm dependencies (npm ci)
+        run: npm ci
+        if: matrix.node >= 8
 
       - name: Run tests
         run: npm run test-coveralls


### PR DESCRIPTION
Fixes #258 

This isn't perfect, but with the current state it works fine. It will fail if one changes `8` to `8.0.0`. I could make it work in this case too, but since we don't use it currently I went with the easiest approach.