### PR TITLE
Correct the count of lines.

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -27,7 +27,7 @@ const convertLcovFileObject = (file, filepath) => {
   const rootpath = filepath;
   filepath = path.resolve(rootpath, file.file);
   const source = fs.readFileSync(filepath, 'utf8');
-  const lines = source.split('\n');
+  const lines = source.split('\n') - 1;
   const coverage = detailsToCoverage(lines.length, file.lines.details);
   const branches = detailsToBranches(file.branches.details);
 


### PR DESCRIPTION
The number of lines in a file is usually computed at the number of newlines in the file minus 1, as described [here](https://codereview.stackexchange.com/questions/131143/counting-newlines-in-a-file).  I also confirmed this by running `wc` on linux with a file that is:

* empty
* non-empty but with no newlines
* with newlines and no trailing newline
* with newlines and with a trailing newline

I noticed this when I saw that the number of lines reported in the file list on coveralls didn't match the number of lines actually in the file.