### PR TITLE
update version in package-lock.json.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coveralls",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
after version bump, we have to run npm install or bump version manually in package-lock.json too,
otherwise it will bump for every contributor when they npm install after cloning the repository,
polluting their diffs if they change anything else in the dependencies.