### PR TITLE
#278 Upgrades minimist dependency to 1.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "coveralls",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1366,9 +1366,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-yaml": "^3.13.1",
     "lcov-parse": "^1.0.0",
     "log-driver": "^1.2.7",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "request": "^2.88.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The current version 1.2.0 has some security issues [please refer](https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764).