### PR TITLE
remove redundant code

### DIFF
--- a/lib/convertLcovToCoveralls.js
+++ b/lib/convertLcovToCoveralls.js
@@ -99,9 +99,7 @@ const convertLcovToCoveralls = (input, options, cb) => {
     if (options.parallel) {
       postJson.parallel = options.parallel;
     }
-    if (options.flag_name) {
-      postJson.flag_name = options.flag_name;
-    }
+
     parsed.forEach(file => {
       file.file = cleanFilePath(file.file);
       const currentFilePath = path.resolve(filepath, file.file);


### PR DESCRIPTION
The check is already done above.

https://github.com/nickmerwin/node-coveralls/blob/eaba7c60d3936ea0d73490486c36ed347149e8c0/lib/convertLcovToCoveralls.js#L67-L69