### PR TITLE
Minor CI tweaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ env:
   CI: true
 
 jobs:
-  run:
+  test:
     name: Node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        node: [6, 8, 10, 12]
+        node: [6, 8, 10, 12, 14]
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -22,9 +22,6 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-
-      - run: node --version
-      - run: npm --version
 
       - name: Install npm dependencies
         run: npm install # switch to `npm ci` when Node.js 6 support is dropped
@@ -43,11 +40,11 @@ jobs:
           parallel: true
 
   finish:
-    needs: run
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
* add Node.js 14
* rename job to test
* uppercase `GITHUB_TOKEN` for consistency
* remove no longer needed steps; `actions-setup-node` prints this by default now

@nickmerwin: We could/should probably not run lint on all Node.js versions since it's moot, but that's for another time 🙂