### PR TITLE
Add GIT_MESSAGE possibility for Jenkins

### DIFF
--- a/lib/getOptions.js
+++ b/lib/getOptions.js
@@ -49,6 +49,7 @@ const getBaseOptions = cb => {
     git_committer_name = process.env.CHANGE_AUTHOR;
     git_committer_email = process.env.CHANGE_AUTHOR_EMAIL;
     git_commit = process.env.GIT_COMMIT;
+    git_message = process.env.GIT_MESSAGE;
     git_branch = process.env.CHANGE_BRANCH || process.env.GIT_BRANCH || process.env.BRANCH_NAME;
   }
 


### PR DESCRIPTION
Right now in my Jenkins/Docker pipeline, I am unable to get the git data. I was able to force the change author/email, but the git message is not available.

```
[2021-11-24T14:30:40.419Z]   git: {
[2021-11-24T14:30:40.419Z]     head: {
[2021-11-24T14:30:40.419Z]       id: 'fc661a128114eb5ddf97858c3773fb281b0ed8dd',
[2021-11-24T14:30:40.419Z]       committer_name: '....',
[2021-11-24T14:30:40.419Z]       committer_email: '....',
[2021-11-24T14:30:40.419Z]       message: 'Unknown Commit Message',
[2021-11-24T14:30:40.419Z]       author_name: 'Unknown Author',
[2021-11-24T14:30:40.419Z]       author_email: ''
```