### PR TITLE
chore: bump minimum nodejs version to 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [6, 8, 10, 12, 14]
+        node: [8, 10, 12, 14, 16, 18]
         os: [ubuntu-latest, windows-latest]
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "xo": "^0.24.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "xo": "^0.24.0"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "files": [
     "bin/coveralls.js",


### PR DESCRIPTION
Bumps minimum nodejs version from v6 to v8.

This is to reflect the current state of things as nodejs v6 throws the following on npm install:

```
npm ERR! Linux 6.2.10-1.qubes.fc32.x86_64
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "i" npm ERR! node v6.17.1
npm ERR! npm  v3.10.10
npm ERR! path /app/node_modules/.staging/@types/minimatch-fad7cd5e/package.json npm ERR! code ENOTDIR
npm ERR! errno -20
npm ERR! syscall open

npm ERR! ENOTDIR: not a directory, open '/app/node_modules/.staging/@types/minimatch-fad7cd5e/package.json' npm ERR!
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /app/npm-debug.log
```


Also updates the CI Matrix accordingly, and adds more recent maintenance releases v16 and v18.